### PR TITLE
Add Royco DecoderAndSanitizer

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
-import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
 import {IRecipeMarketHub} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";
 

--- a/src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
+import {IRecipeMarketHub} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";
+
+abstract contract RoycoWeirollDecoderAndSanitizer is ERC4626DecoderAndSanitizer {
+    //============================== ERRORS ===============================
+
+    error RoycoWeirollDecoderAndSanitizer__TooManyOfferHashes();
+
+    //============================== IMMUTABLES ===============================
+
+    IRecipeMarketHub internal immutable recipeMarketHub;
+
+    constructor(address _recipeMarketHub) ERC4626DecoderAndSanitizer() {
+        recipeMarketHub = IRecipeMarketHub(_recipeMarketHub);
+    }
+
+    // DepositorExecutor
+    function merkleWithdraw() external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+    function withdrawMerkleDeposit(
+        address _weirollWallet,
+        uint256, /*_merkleDepositNonce*/
+        uint256, /*_amountDepositedOnSource*/
+        bytes32[] calldata /*_merkleProof*/
+    ) external pure virtual returns (bytes memory addressesFound) {
+        addressesFound = abi.encodePacked(_weirollWallet);
+    }
+
+    // RecipeMarketHub
+    function createAPOffer(
+        bytes32 targetMarketHash,
+        address fundingVault,
+        uint256, /*quantity*/
+        uint256, /*expiry*/
+        address[] calldata incentivesRequested,
+        uint256[] calldata /*incentiveAmountsRequested*/
+    ) external pure virtual returns (bytes memory addressesFound) {
+        address marketHash0 = address(bytes20(bytes16(targetMarketHash)));
+        address marketHash1 = address(bytes20(bytes16(targetMarketHash << 128)));
+        addressesFound = abi.encodePacked(marketHash0, marketHash1, fundingVault);
+        for (uint256 i = 0; i < incentivesRequested.length; i++) {
+            addressesFound = abi.encodePacked(addressesFound, incentivesRequested[i]);
+        }
+    }
+
+    function cancelAPOffer(
+        DecoderCustomTypes.APOffer calldata offer
+    ) external pure virtual returns (bytes memory addressesFound) {
+        address marketHash0 = address(bytes20(bytes16(offer.targetMarketHash)));
+        address marketHash1 = address(bytes20(bytes16(offer.targetMarketHash << 128)));
+        addressesFound = abi.encodePacked(marketHash0, marketHash1, offer.ap, offer.fundingVault);
+        for (uint256 i = 0; i < offer.incentivesRequested.length; i++) {
+            addressesFound = abi.encodePacked(addressesFound, offer.incentivesRequested[i]);
+        }
+    }
+
+    function fillIPOffers(
+        bytes32[] calldata ipOfferHashes,
+        uint256[] calldata, /*fillAmounts*/
+        address fundingVault,
+        address frontendFeeRecipient
+    ) external view virtual returns (bytes memory addressesFound) {
+        if (ipOfferHashes.length != 1) revert RoycoWeirollDecoderAndSanitizer__TooManyOfferHashes();
+
+        (, bytes32 marketHash,,,,) = recipeMarketHub.offerHashToIPOffer(ipOfferHashes[0]);
+
+        address marketHash0 = address(bytes20(bytes16(marketHash)));
+        address marketHash1 = address(bytes20(bytes16(marketHash << 128)));
+        return abi.encodePacked(marketHash0, marketHash1, fundingVault, frontendFeeRecipient);
+    }
+
+    function executeWithdrawalScript(
+        address weirollWallet
+    ) external view virtual returns (bytes memory addressesFound) {
+        //WeirollWallet will check that the caller is owner (boring vault)
+        //but we check here before delegating for safety.
+        address owner = IWeirollWalletHelper(weirollWallet).owner();
+        return abi.encodePacked(owner);
+    }
+
+    function forfeit(
+        address weirollWallet,
+        bool /*executeWithdraw*/
+    ) external view virtual returns (bytes memory addressesFound) {
+        //WeirollWallet will check that the caller is owner (boring vault)
+        //but we check here before delegating for safety.
+        address owner = IWeirollWalletHelper(weirollWallet).owner();
+        addressesFound = abi.encodePacked(owner);
+    }
+
+    function claim(address weirollWallet, address to) external view virtual returns (bytes memory addressesFound) {
+        address owner = IWeirollWalletHelper(weirollWallet).owner();
+        addressesFound = abi.encodePacked(owner, to);
+    }
+
+    // VaultMarketHub
+    function createAPOffer(
+        address targetVault,
+        address fundingVault,
+        uint256, /*quantity*/
+        uint256, /*expiry*/
+        address[] calldata incentivesRequested,
+        uint256[] calldata /*incentivesRatesRequested*/
+    ) external pure virtual returns (bytes memory addressesFound) {
+        for (uint256 i = 0; i < incentivesRequested.length; i++) {
+            addressesFound = abi.encodePacked(addressesFound, incentivesRequested[i]);
+        }
+        addressesFound = abi.encodePacked(targetVault, fundingVault, addressesFound);
+    }
+
+    // WrappedVault (other functions handled by ERC4626 decoder)
+    function safeDeposit(
+        uint256, /*assets*/
+        address receiver,
+        uint256 /*minShares*/
+    ) external pure virtual returns (bytes memory addressesFound) {
+        addressesFound = abi.encodePacked(receiver);
+    }
+
+    function claim(
+        address to
+    ) external pure virtual returns (bytes memory addressesFound) {
+        addressesFound = abi.encodePacked(to);
+    }
+}
+
+interface IWeirollWalletHelper {
+    function owner() external view returns (address);
+}

--- a/src/interfaces/DecoderCustomTypes.sol
+++ b/src/interfaces/DecoderCustomTypes.sol
@@ -409,4 +409,17 @@ contract DecoderCustomTypes {
         address asset;
         uint256 amount;
     }
+
+    // ========================================= Royco ==================================
+    
+    struct APOffer {
+        uint256 offerID;
+        bytes32 targetMarketHash;
+        address ap;
+        address fundingVault;
+        uint256 quantity;
+        uint256 expiry;
+        address[] incentivesRequested;
+        uint256[] incentiveAmountsRequested;
+    }
 }

--- a/src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol
+++ b/src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol
@@ -79,3 +79,25 @@ interface CamelotNonFungiblePositionManager {
             uint128 tokensOwed1
         );
 }
+
+interface IRecipeMarketHub {
+    enum RewardStyle {
+        Upfront,
+        Arrear,
+        Forfeitable
+    }
+    /// @custom:field weirollCommands The weiroll script that will be executed on an AP's weiroll wallet after receiving the inputToken
+    /// @custom:field weirollState State of the weiroll VM, necessary for executing the weiroll script
+    struct Recipe {
+        bytes32[] weirollCommands;
+        bytes[] weirollState;
+    }
+    function offerHashToIPOffer(bytes32 offer)
+        external
+        view
+        returns (uint256, bytes32, address, uint256, uint256, uint256);
+    function marketHashToWeirollMarket(bytes32 marketHash)
+        external
+        view
+        returns (uint256, address, uint256, uint256, Recipe memory, Recipe memory, RewardStyle);
+}

--- a/test/integrations/BaseTestIntegration.t.sol
+++ b/test/integrations/BaseTestIntegration.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {ERC4626} from "@solmate/tokens/ERC4626.sol";
+import {RoycoWeirollDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/protocols/RoycoDecoderAndSanitizer.sol"; 
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+
+
+contract BaseTestIntegration is Test, MerkleTreeHelper {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    struct Tx {
+        ManageLeaf[] manageLeafs;  
+        address[] targets;  
+        bytes[] targetData; 
+        address[] decodersAndSanitizers;
+        uint256[] values;    
+    }
+
+    ManagerWithMerkleVerification public manager;
+    BoringVault public boringVault;
+    address public rawDataDecoderAndSanitizer;
+    RolesAuthority public rolesAuthority;
+
+    uint8 public constant MANAGER_ROLE = 1;
+    uint8 public constant STRATEGIST_ROLE = 2;
+    uint8 public constant MANGER_INTERNAL_ROLE = 3;
+    uint8 public constant ADMIN_ROLE = 4;
+    uint8 public constant BORING_VAULT_ROLE = 5;
+    uint8 public constant BALANCER_VAULT_ROLE = 6;
+    
+    mapping(string => string) public nameToRPC; 
+
+    function setUp() public virtual {
+        nameToRPC["mainnet"] = "MAINNET_RPC_URL";  
+        nameToRPC["base"] = "BASE_RPC_URL";  
+        nameToRPC["arbitrum"] = "ARBITRUM_RPC_URL";  
+        nameToRPC["sonicMainnet"] = "SONIC_MAINNET_RPC_URL";  
+        nameToRPC["berchain"] = "BERA_CHAIN_RPC_URL";  
+        nameToRPC["bsc"] = "BNB_RPC_URL"; 
+        nameToRPC["swell"] = "SWELL_CHAIN_RLC_URL"; 
+    }
+    
+    function _setupChain(string memory chain, uint256 blockNumber) internal {
+
+        setSourceChainName(chain);
+        // Setup forked environment.
+        string memory rpcKey = nameToRPC[chain]; 
+
+        _startFork(rpcKey, blockNumber);
+
+        boringVault = new BoringVault(address(this), "Boring Vault", "BV", 18);
+        setAddress(false, sourceChain, "boringVault", address(boringVault));
+
+        manager =
+            new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
+
+        rawDataDecoderAndSanitizer = address(
+            new FullRoycoDecoderAndSanitizer(getAddress(sourceChain, "boringVault"), getAddress(sourceChain, "recipeMarketHub"))
+        );
+
+        setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
+        setAddress(false, sourceChain, "manager", address(manager));
+        setAddress(false, sourceChain, "managerAddress", address(manager));
+        setAddress(false, sourceChain, "accountantAddress", address(1));
+
+        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
+        boringVault.setAuthority(rolesAuthority);
+        manager.setAuthority(rolesAuthority);
+
+        // Setup roles authority.
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address,bytes,uint256)"))),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address[],bytes[],uint256[])"))),
+            true
+        );
+
+        rolesAuthority.setRoleCapability(
+            STRATEGIST_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANGER_INTERNAL_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(manager), ManagerWithMerkleVerification.setManageRoot.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BORING_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.flashLoan.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BALANCER_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.receiveFlashLoan.selector, true
+        );
+
+        // Grant roles
+        rolesAuthority.setUserRole(address(this), STRATEGIST_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANGER_INTERNAL_ROLE, true);
+        rolesAuthority.setUserRole(address(this), ADMIN_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANAGER_ROLE, true);
+        rolesAuthority.setUserRole(address(boringVault), BORING_VAULT_ROLE, true);
+        rolesAuthority.setUserRole(getAddress(sourceChain, "vault"), BALANCER_VAULT_ROLE, true);
+    }
+
+    function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
+        forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
+        vm.selectFork(forkId);
+    }
+
+    function _overrideDecoder(address newDecoder) internal {
+        setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", newDecoder);
+        rawDataDecoderAndSanitizer = newDecoder; 
+    }
+
+    function _getTxArrays(uint256 size) internal pure returns (Tx memory) {
+        Tx memory tx_; 
+
+        tx_.manageLeafs = new ManageLeaf[](size); 
+        tx_.targets = new address[](size); 
+        tx_.targetData = new bytes[](size); 
+        tx_.decodersAndSanitizers = new address[](size); 
+        tx_.values = new uint256[](size); 
+
+        return tx_; 
+    }
+
+    function _submitManagerCall(bytes32[][] memory proofs, Tx memory tx_) internal {
+        manager.manageVaultWithMerkleVerification(proofs, tx_.decodersAndSanitizers, tx_.targets, tx_.targetData, tx_.values);
+    }
+}
+
+contract FullRoycoDecoderAndSanitizer is RoycoWeirollDecoderAndSanitizer {
+    constructor(address _boringVault, address _recipeMarketHub) BaseDecoderAndSanitizer(_boringVault) RoycoWeirollDecoderAndSanitizer(_recipeMarketHub) {}
+}

--- a/test/integrations/RoycoIntegration.t.sol
+++ b/test/integrations/RoycoIntegration.t.sol
@@ -1,0 +1,631 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {BaseTestIntegration, FullRoycoDecoderAndSanitizer} from "test/integrations/BaseTestIntegration.t.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {ERC4626} from "@solmate/tokens/ERC4626.sol";
+import {RoycoWeirollDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol";
+import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
+import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+
+contract RoycoIntegrationTest is BaseTestIntegration {
+    function _setUpMainnet() internal {
+        super.setUp();
+        _setupChain("mainnet", 21713448);
+
+        address roycoDecoder = address(new FullRoycoDecoderAndSanitizer(getAddress(sourceChain, "boringVault"), 0x783251f103555068c1E9D755f69458f39eD937c0));
+
+        _overrideDecoder(roycoDecoder);
+    }
+
+    function _setUpSonic() internal {
+        super.setUp();
+        _setupChain("sonicMainnet", 14684422);
+
+        address roycoDecoder = address(new FullRoycoDecoderAndSanitizer(getAddress(sourceChain, "boringVault"), 0xFcc593aD3705EBcd72eC961c63eb484BE795BDbD));
+
+        _overrideDecoder(roycoDecoder);
+    }
+
+    function testRoycoERC4626Integration() external {
+        _setUpMainnet();
+        //deal(getAddress(sourceChain, "USDC"), address(boringVault), 1_000e6);
+        vm.prank(0x28C6c06298d514Db089934071355E5743bf21d60);
+        ERC20(getAddress(sourceChain, "USDC")).transfer(address(boringVault), 100_000e6);
+        runRoycoERC4626Integration(getAddress(sourceChain, "supplyUSDCAaveWrappedVault"));
+    }
+
+    function testRoycoERC4626IntegrationClaiming() external {
+        _setUpMainnet();
+        //deal(getAddress(sourceChain, "USDC"), address(boringVault), 1_000e6);
+        vm.prank(0x28C6c06298d514Db089934071355E5743bf21d60);
+        ERC20(getAddress(sourceChain, "USDC")).transfer(address(boringVault), 100_000e6);
+
+        runRoycoERC4626Integration(getAddress(sourceChain, "supplyUSDCAaveWrappedVault"));
+    }
+
+    function testRoycoWeirollForfeitIntegration() external {
+        _setUpMainnet();
+        address asset = getAddress(sourceChain, "USDC");
+        //deal(asset, address(boringVault), 1_000e6);
+        vm.prank(0x28C6c06298d514Db089934071355E5743bf21d60);
+        ERC20(asset).transfer(address(boringVault), 100_000e6);
+
+        bytes32 stkGHOMarketHash = 0x83c459782b2ff36629401b1a592354fc085f29ae00cf97b803f73cac464d389b;
+        bytes32 stkGHOHash = 0x8349eff9a17d01f2e9fa015121d0d03cd4b15ae9f2b8b17add16bbad006a1c6a;
+        address expectedWeirollWallet = 0xF2075aBc3cC8EE8F75F28Ac9A3c5CAeBe1E9C7Cb;
+        runRoycoWeirollForfeitIntegration(asset, stkGHOMarketHash, stkGHOHash, expectedWeirollWallet);
+    }
+
+    function testRoycoWeirollExecuteWithdrawIntegrationComplete() external {
+        _setUpMainnet();
+        address asset = getAddress(sourceChain, "USDC");
+        //deal(asset, address(boringVault), 1_000e6);
+        vm.prank(0x28C6c06298d514Db089934071355E5743bf21d60);
+        ERC20(getAddress(sourceChain, "USDC")).transfer(address(boringVault), 100_000e6);
+
+        bytes32 stkGHOMarketHash = 0x83c459782b2ff36629401b1a592354fc085f29ae00cf97b803f73cac464d389b;
+        bytes32 stkGHOHash = 0x8349eff9a17d01f2e9fa015121d0d03cd4b15ae9f2b8b17add16bbad006a1c6a;
+        address expectedWeirollWallet = 0xF2075aBc3cC8EE8F75F28Ac9A3c5CAeBe1E9C7Cb;
+        runRoycoWeirollExecuteWithdrawIntegrationComplete(asset, stkGHOMarketHash, stkGHOHash, expectedWeirollWallet);
+    }
+
+    function testRoycoWeirollExecuteWithdrawIntegration() external {
+        _setUpMainnet();
+        address asset = getAddress(sourceChain, "WBTC");
+        deal(asset, address(boringVault), 100_000e6);
+        bytes32 wbtcMarketHash = 0xb36f14fd392b9a1d6c3fabedb9a62a63d2067ca0ebeb63bbc2c93b11cc8eb3a2;
+        bytes32 wbtcFillOfferHash = 0xe6d27a147193a240619759a35ebed3b4c2bd931cc3aaf9887c37724eea46f235;
+        runRoycoWeirollExecuteWithdrawIntegration(asset, wbtcMarketHash, wbtcFillOfferHash);
+    }
+
+    function testRoycoWeirollVaultMarketHubIntegration() external {
+        _setUpMainnet();
+        address asset = getAddress(sourceChain, "USDC");
+        address vault = getAddress(sourceChain, "supplyUSDCAaveWrappedVault");
+        //deal(getAddress(sourceChain, "USDC"), address(boringVault), 100_000e6);
+        vm.prank(0x28C6c06298d514Db089934071355E5743bf21d60);
+        ERC20(getAddress(sourceChain, "USDC")).transfer(address(boringVault), 100_000e6);
+        runRoycoWeirollVaultMarketHubIntegration(asset, vault);
+    }
+
+    function testRoycoWeirollRecipeMarketHubIntegration() external {
+        _setUpMainnet();
+        address asset = getAddress(sourceChain, "USDC");
+        //deal(asset, address(boringVault), 100_000e6);
+        vm.prank(0x28C6c06298d514Db089934071355E5743bf21d60);
+        ERC20(getAddress(sourceChain, "USDC")).transfer(address(boringVault), 100_000e6);
+        
+        bytes32 targetMarketHash = 0x83c459782b2ff36629401b1a592354fc085f29ae00cf97b803f73cac464d389b; //swap USDC to stkGHO market hash
+        uint256 offerId = 11; // this depends on how many offers have been made at the point we are forking from
+        runRoycoWeirollRecipeMarketHubIntegration(asset, targetMarketHash, offerId);
+    }
+
+    function testRoycoERC4626IntegrationSonic() external {
+        _setUpSonic();
+        //deal(getAddress(sourceChain, "OS"), address(boringVault), 100_000e18); -- does not work with OS
+        vm.prank(0x86D888C3fA8A7F67452eF2Eccc1C5EE9751Ec8d6); // account with a lot of OS
+        ERC20(getAddress(sourceChain, "OS")).transfer(address(boringVault), 100_000e18);
+        runRoycoERC4626Integration(getAddress(sourceChain, "originSonicWrappedVault"));
+    }
+
+    function testRoycoERC4626IntegrationClaimingSonic() external {
+        _setUpSonic();
+        //deal(getAddress(sourceChain, "OS"), address(boringVault), 100_000e18); -- does not work with OS
+        vm.prank(0x86D888C3fA8A7F67452eF2Eccc1C5EE9751Ec8d6); // account with a lot of OS
+        ERC20(getAddress(sourceChain, "OS")).transfer(address(boringVault), 100_000e18);
+        runRoycoERC4626Integration(getAddress(sourceChain, "originSonicWrappedVault"));
+    }
+
+    function testRoycoWeirollForfeitIntegrationSonic() external {
+        _setUpSonic();
+        address asset = getAddress(sourceChain, "USDC");
+        //deal(asset, address(boringVault), 1_000e6);
+        vm.prank(0x2F500d4178D36ae358898b6cA398f2CFca0DAfF6);
+        ERC20(asset).transfer(address(boringVault), 100_000e6);
+
+        bytes32 scUSDMarketHash = 0x7d1f2a66eabf9142dd30d1355efcbfd4cfbefd2872d24ca9855641434816a525;
+        bytes32 ipOfferHash = 0xcd3b9f1c7a3f90bf397c46f2a641315d6e81d063811d4ccfc683046e33f323e9;
+        address expectedWeirollWallet = 0x119D69120c9940a9D8eE78A35f865d39bF08A622;
+
+        runRoycoWeirollForfeitIntegration(asset, scUSDMarketHash, ipOfferHash, expectedWeirollWallet);
+    }
+
+    function testRoycoWeirollExecuteWithdrawIntegrationCompleteSonic() external {
+        _setUpSonic();
+        address asset = getAddress(sourceChain, "USDC");
+        //deal(asset, address(boringVault), 1_000e6);
+        vm.prank(0x2F500d4178D36ae358898b6cA398f2CFca0DAfF6);
+        ERC20(asset).transfer(address(boringVault), 100_000e6);
+        bytes32 scUSDMarketHash = 0x7d1f2a66eabf9142dd30d1355efcbfd4cfbefd2872d24ca9855641434816a525;
+        bytes32 ipOfferHash = 0xcd3b9f1c7a3f90bf397c46f2a641315d6e81d063811d4ccfc683046e33f323e9;
+        address expectedWeirollWallet = 0x119D69120c9940a9D8eE78A35f865d39bF08A622;
+        runRoycoWeirollExecuteWithdrawIntegrationComplete(asset, scUSDMarketHash, ipOfferHash, expectedWeirollWallet);
+    }
+
+    function testRoycoWeirollExecuteWithdrawIntegrationSonic() external {
+        _setUpSonic();
+        address asset = getAddress(sourceChain, "USDC");
+        //deal(asset, address(boringVault), 1_000e6);
+        vm.prank(0x2F500d4178D36ae358898b6cA398f2CFca0DAfF6);
+        ERC20(asset).transfer(address(boringVault), 100_000e6);
+        bytes32 scUSDMarketHash = 0x7d1f2a66eabf9142dd30d1355efcbfd4cfbefd2872d24ca9855641434816a525;
+        bytes32 ipOfferHash = 0xcd3b9f1c7a3f90bf397c46f2a641315d6e81d063811d4ccfc683046e33f323e9;
+        //address expectedWeirollWallet = 0x119D69120c9940a9D8eE78A35f865d39bF08A622;
+        runRoycoWeirollExecuteWithdrawIntegration(asset, scUSDMarketHash, ipOfferHash);
+    }
+
+    function testRoycoWeirollVaultMarketHubIntegrationSonic() external {
+        _setUpSonic();
+        //deal(getAddress(sourceChain, "OS"), address(boringVault), 100_000e18); -- does not work with OS
+        address asset = getAddress(sourceChain, "OS");
+        address vault = getAddress(sourceChain, "originSonicWrappedVault");
+        vm.prank(0x86D888C3fA8A7F67452eF2Eccc1C5EE9751Ec8d6); // account with a lot of OS
+        ERC20(getAddress(sourceChain, "OS")).transfer(address(boringVault), 100_000e18);
+        runRoycoWeirollVaultMarketHubIntegration(asset, vault);
+    }
+
+    function testRoycoWeirollRecipeMarketHubIntegrationSonic() external {
+        _setUpSonic();
+        address asset = getAddress(sourceChain, "USDC");
+        //deal(asset, address(boringVault), 100_000e6);
+        vm.prank(0x2F500d4178D36ae358898b6cA398f2CFca0DAfF6);
+        ERC20(asset).transfer(address(boringVault), 100_000e6);
+        bytes32 targetMarketHash = 0x7d1f2a66eabf9142dd30d1355efcbfd4cfbefd2872d24ca9855641434816a525; // Deposit USDC into Rings to Mint and Stake scUSD
+        uint256 offerId = 4; // this depends on how many offers have been made at the point we are forking from
+        runRoycoWeirollRecipeMarketHubIntegration(asset, targetMarketHash, offerId);
+    }
+
+    // ========================================= HELPER FUNCTIONS =========================================
+    function runRoycoERC4626Integration(address vault) internal {
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        _addERC4626Leafs(leafs, ERC4626(vault));
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](5);
+        manageLeafs[0] = leafs[0]; //approve
+        manageLeafs[1] = leafs[1]; //deposit
+        manageLeafs[2] = leafs[2]; //withdraw
+        manageLeafs[3] = leafs[3]; //mint
+        manageLeafs[4] = leafs[4]; //redeem
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address asset = address(ERC4626(vault).asset());
+
+        //we are supplying to the wrapped vault.
+        address[] memory targets = new address[](5);
+        targets[0] = asset;
+        targets[1] = vault;
+        targets[2] = vault;
+        targets[3] = vault;
+        targets[4] = vault;
+
+        bytes[] memory targetData = new bytes[](5);
+        targetData[0] = abi.encodeWithSignature("approve(address,uint256)", vault, type(uint256).max);
+        targetData[1] = abi.encodeWithSignature(
+            "deposit(uint256,address)", 100 * (10 ** ERC20(asset).decimals()), getAddress(sourceChain, "boringVault")
+        );
+        targetData[2] = abi.encodeWithSignature(
+            "withdraw(uint256,address,address)",
+            90 * (10 ** ERC20(asset).decimals()),
+            getAddress(sourceChain, "boringVault"),
+            getAddress(sourceChain, "boringVault")
+        );
+        targetData[3] = //mint 10 shares
+        abi.encodeWithSignature(
+            "mint(uint256,address)", 10 * (10 ** ERC4626(vault).decimals()), getAddress(sourceChain, "boringVault")
+        );
+        targetData[4] = //redeem 10 shares
+        abi.encodeWithSignature(
+            "redeem(uint256,address,address)",
+            10 * (10 ** ERC4626(vault).decimals()),
+            getAddress(sourceChain, "boringVault"),
+            getAddress(sourceChain, "boringVault")
+        );
+
+        address[] memory decodersAndSanitizers = new address[](5);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[2] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[3] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[4] = rawDataDecoderAndSanitizer;
+
+        uint256[] memory values = new uint256[](5);
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    function runRoycoERC4626IntegrationClaiming(address vault) internal {
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        _addRoyco4626VaultLeafs(leafs, ERC4626(vault));
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
+        manageLeafs[0] = leafs[0]; //approve
+        manageLeafs[1] = leafs[1]; //deposit
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address asset = address(ERC4626(vault).asset());
+        //we are supplying asset into wrappedVault.
+        address[] memory targets = new address[](2);
+        targets[0] = asset;
+        targets[1] = vault;
+
+        bytes[] memory targetData = new bytes[](2);
+        targetData[0] = abi.encodeWithSignature("approve(address,uint256)", vault, type(uint256).max);
+        targetData[1] = abi.encodeWithSignature(
+            "deposit(uint256,address)", 100 * (10 ** ERC20(asset).decimals()), getAddress(sourceChain, "boringVault")
+        );
+
+        address[] memory decodersAndSanitizers = new address[](2);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+        uint256[] memory values = new uint256[](2);
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+
+        //skip some time
+        skip(12 weeks);
+
+        manageLeafs[0] = leafs[5]; //claim
+        manageLeafs[1] = leafs[6]; //claimFees
+
+        manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        targets[0] = vault;
+        targets[1] = vault;
+
+        targetData[0] = abi.encodeWithSignature("claim(address)", getAddress(sourceChain, "boringVault"));
+        targetData[1] = abi.encodeWithSignature("claimFees(address)", getAddress(sourceChain, "boringVault"));
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    function runRoycoWeirollForfeitIntegration(
+        address asset,
+        bytes32 marketHash,
+        bytes32 offerHash,
+        address expectedWeirollWallet
+    ) internal {
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        _addRoycoWeirollLeafs(leafs, ERC20(asset), marketHash, getAddress(sourceChain, "boringVault"));
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        //first we'll check early unlocks and forfeits
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
+        manageLeafs[0] = leafs[0]; //approve
+        manageLeafs[1] = leafs[1]; //fillIPOffers (execute deposit script)
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        //we are interacting the recipe market
+        address[] memory targets = new address[](2);
+        targets[0] = asset;
+        targets[1] = getAddress(sourceChain, "recipeMarketHub");
+
+        bytes32[] memory ipOfferHashes = new bytes32[](1);
+        ipOfferHashes[0] = offerHash;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100 * (10 ** ERC20(asset).decimals());
+
+        bytes[] memory targetData = new bytes[](2);
+        targetData[0] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "recipeMarketHub"), type(uint256).max
+        );
+        targetData[1] = abi.encodeWithSignature(
+            "fillIPOffers(bytes32[],uint256[],address,address)",
+            ipOfferHashes,
+            amounts,
+            address(0),
+            getAddress(sourceChain, "boringVault")
+        );
+
+        address[] memory decodersAndSanitizers = new address[](2);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+        uint256[] memory values = new uint256[](2);
+
+        //execute deposit script
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+
+        ///Test Withdraws
+
+        //accrue some rewards
+        skip(7 days);
+
+        bool executeWithdraw = true;
+
+        ManageLeaf[] memory manageLeafs2 = new ManageLeaf[](1);
+        manageLeafs2[0] = leafs[3]; //forfeit
+
+        manageProofs = _getProofsUsingTree(manageLeafs2, manageTree);
+
+        targets = new address[](1);
+        targets[0] = getAddress(sourceChain, "recipeMarketHub");
+
+        targetData = new bytes[](1);
+        targetData[0] = abi.encodeWithSignature("forfeit(address,bool)", expectedWeirollWallet, executeWithdraw);
+
+        decodersAndSanitizers = new address[](1);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+
+        values = new uint256[](1);
+
+        //execute forfeit script with rewards accrued
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    function runRoycoWeirollExecuteWithdrawIntegrationComplete(
+        address asset,
+        bytes32 marketHash,
+        bytes32 offerHash,
+        address expectedWeirollWallet
+    ) internal {
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        _addRoycoWeirollLeafs(leafs, ERC20(asset), marketHash, getAddress(sourceChain, "boringVault"));
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        //first we'll check early unlocks and forfeits
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
+        manageLeafs[0] = leafs[0]; //approve
+        manageLeafs[1] = leafs[1]; //fillIPOffers (execute deposit script)
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        //we are interacting with the recipe market
+        address[] memory targets = new address[](2);
+        targets[0] = asset;
+        targets[1] = getAddress(sourceChain, "recipeMarketHub");
+
+        bytes32[] memory ipOfferHashes = new bytes32[](1);
+        ipOfferHashes[0] = offerHash; //stkGHO offer hash from: https://etherscan.io/tx/0x133e477a7573555df912bba020c3a5e3c3b137a21a76c8f52b3b5a7a2065f2e0
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100 * (10 ** ERC20(asset).decimals());
+
+        bytes[] memory targetData = new bytes[](2);
+        targetData[0] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "recipeMarketHub"), type(uint256).max
+        );
+        targetData[1] = abi.encodeWithSignature(
+            "fillIPOffers(bytes32[],uint256[],address,address)",
+            ipOfferHashes,
+            amounts,
+            address(0),
+            getAddress(sourceChain, "boringVault")
+        );
+
+        address[] memory decodersAndSanitizers = new address[](2);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+        uint256[] memory values = new uint256[](2);
+
+        //execute deposit script
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+
+        ///Test Withdraws
+
+        //accrue some rewards
+        skip(40 days);
+
+        ManageLeaf[] memory manageLeafs2 = new ManageLeaf[](2);
+        manageLeafs2[0] = leafs[2]; //executeWithdrawalScript
+        manageLeafs2[1] = leafs[4]; //executeWithdrawalScript
+
+        manageProofs = _getProofsUsingTree(manageLeafs2, manageTree);
+
+        targets = new address[](2);
+        targets[0] = getAddress(sourceChain, "recipeMarketHub");
+        targets[1] = getAddress(sourceChain, "recipeMarketHub");
+
+        targetData = new bytes[](2);
+        targetData[0] = abi.encodeWithSignature("executeWithdrawalScript(address)", expectedWeirollWallet);
+        targetData[1] = abi.encodeWithSignature(
+            "claim(address,address)", expectedWeirollWallet, getAddress(sourceChain, "boringVault")
+        );
+
+        decodersAndSanitizers = new address[](2);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+        values = new uint256[](2);
+
+        //execute forfeit script with rewards accrued
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    function runRoycoWeirollExecuteWithdrawIntegration(address asset, bytes32 marketHash, bytes32 offerHash) internal {
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        _addRoycoWeirollLeafs(leafs, ERC20(asset), marketHash, getAddress(sourceChain, "boringVault"));
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        //first we'll check early unlocks and forfeits
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
+        manageLeafs[0] = leafs[0]; //approve
+        manageLeafs[1] = leafs[1]; //fillIPOffers (execute deposit script)
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        //we are interacting the stkGHO market
+        address[] memory targets = new address[](2);
+        targets[0] = asset;
+        targets[1] = getAddress(sourceChain, "recipeMarketHub");
+
+        bytes32[] memory ipOfferHashes = new bytes32[](1);
+        ipOfferHashes[0] = offerHash;
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100 * (10 ** ERC20(asset).decimals());
+
+        bytes[] memory targetData = new bytes[](2);
+        targetData[0] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "recipeMarketHub"), type(uint256).max
+        );
+        targetData[1] = abi.encodeWithSignature(
+            "fillIPOffers(bytes32[],uint256[],address,address)",
+            ipOfferHashes,
+            amounts,
+            address(0),
+            getAddress(sourceChain, "boringVault")
+        );
+
+        address[] memory decodersAndSanitizers = new address[](2);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+        uint256[] memory values = new uint256[](2);
+
+        //execute deposit script
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    function runRoycoWeirollVaultMarketHubIntegration(address asset, address vault) internal {
+        // we can request arbitrary assets in return for our actions
+        address[] memory incentivesRequested = new address[](2);
+        incentivesRequested[0] = getAddress(sourceChain, "WBTC");
+        incentivesRequested[1] = getAddress(sourceChain, "WETH");
+        uint256[] memory amountsRequested = new uint256[](2);
+        amountsRequested[0] = 1e8;
+        amountsRequested[1] = 10e18;
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        // fundingVault = address(0) means pull funds from caller (boringVault)
+        _addRoycoVaultMarketLeafs(leafs, asset, vault, address(0), incentivesRequested);
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](4);
+        manageLeafs[0] = leafs[0]; //approve WrappedVault
+        manageLeafs[1] = leafs[1]; //safeDeposit
+        manageLeafs[2] = leafs[2]; //approve VaultMarketHub
+        manageLeafs[3] = leafs[3]; //createAPOffer
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address[] memory targets = new address[](4);
+        targets[0] = asset;
+        targets[1] = vault;
+        targets[2] = asset;
+        targets[3] = getAddress(sourceChain, "vaultMarketHub");
+
+        bytes[] memory targetData = new bytes[](4);
+        targetData[0] = abi.encodeWithSignature("approve(address,uint256)", vault, type(uint256).max);
+        targetData[1] = abi.encodeWithSignature(
+            "safeDeposit(uint256,address,uint256)",
+            100 * (10 ** ERC20(asset).decimals()),
+            getAddress(sourceChain, "boringVault"),
+            88 * (10 ** ERC20(asset).decimals())
+        );
+        targetData[2] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "vaultMarketHub"), type(uint256).max
+        );
+        targetData[3] = abi.encodeWithSignature(
+            "createAPOffer(address,address,uint256,uint256,address[],uint256[])",
+            vault,
+            address(0),
+            100 * (10 ** ERC20(asset).decimals()),
+            1773880121, // March 19 2026
+            incentivesRequested,
+            amountsRequested
+        );
+
+        address[] memory decodersAndSanitizers = new address[](4);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[2] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[3] = rawDataDecoderAndSanitizer;
+
+        uint256[] memory values = new uint256[](4);
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    function runRoycoWeirollRecipeMarketHubIntegration(address asset, bytes32 targetMarketHash, uint256 offerId)
+        internal
+    {
+        address[] memory incentivesRequested = new address[](2);
+        incentivesRequested[0] = getAddress(sourceChain, "WBTC");
+        incentivesRequested[1] = getAddress(sourceChain, "WETH");
+        uint256[] memory amountsRequested = new uint256[](2);
+        amountsRequested[0] = 1e8;
+        amountsRequested[1] = 10e18;
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        _addRoycoRecipeAPOfferLeafs(leafs, asset, targetMarketHash, address(0), incentivesRequested);
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](3);
+        manageLeafs[0] = leafs[0];
+        manageLeafs[1] = leafs[1];
+        manageLeafs[2] = leafs[2];
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address[] memory targets = new address[](3);
+        targets[0] = asset;
+        targets[1] = getAddress(sourceChain, "recipeMarketHub");
+        targets[2] = getAddress(sourceChain, "recipeMarketHub");
+
+        bytes[] memory targetData = new bytes[](3);
+        targetData[0] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "recipeMarketHub"), type(uint256).max
+        );
+        targetData[1] = abi.encodeWithSignature(
+            "createAPOffer(bytes32,address,uint256,uint256,address[],uint256[])",
+            targetMarketHash,
+            address(0),
+            100 * (10 ** ERC20(asset).decimals()),
+            1773880121, // March 19 2026
+            incentivesRequested,
+            amountsRequested
+        );
+        targetData[2] = abi.encodeWithSignature(
+            "cancelAPOffer((uint256,bytes32,address,address,uint256,uint256,address[],uint256[]))",
+            DecoderCustomTypes.APOffer(
+                offerId, // this depends on when we are forking from
+                targetMarketHash,
+                getAddress(sourceChain, "boringVault"), // msg.sender of createAPOffer call
+                address(0),
+                100 * (10 ** ERC20(asset).decimals()),
+                1773880121, // March 19 2026
+                incentivesRequested,
+                amountsRequested
+            )
+        );
+
+        address[] memory decodersAndSanitizers = new address[](3);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[2] = rawDataDecoderAndSanitizer;
+
+        uint256[] memory values = new uint256[](3);
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+}

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -22,6 +22,7 @@ contract ChainValues {
     string public constant fraxtal = "fraxtal";
     string public constant corn = "corn";
     string public constant holesky = "holesky";
+    string public constant sonicMainnet = "sonicMainnet";
 
     // Bridging constants.
     uint64 public constant ccipArbitrumChainSelector = 4949039107694359620;
@@ -85,6 +86,7 @@ contract ChainValues {
         _addFraxtalValues();
         _addBscValues();
         _addCornValues();
+        _addSonicMainnetValues();
 
         // Add testnet values
         _addHoleskyValues();
@@ -866,6 +868,11 @@ contract ChainValues {
         // Hyperlane
         values[mainnet]["hyperlaneUsdcRouter"] = 0xe1De9910fe71cC216490AC7FCF019e13a34481D7.toBytes32();
         values[mainnet]["hyperlaneTestRecipient"] = 0xfb53392bf4a0590a317ca716c28c29ace7c448bc132d7f8188ca234f595aa121;
+        // Royco
+        values[mainnet]["vaultMarketHub"] = 0xa97eCc6Bfda40baf2fdd096dD33e88bd8e769280.toBytes32();
+        values[mainnet]["recipeMarketHub"] = 0x783251f103555068c1E9D755f69458f39eD937c0.toBytes32();
+        values[mainnet]["supplyUSDCAaveWrappedVault"] = 0x2120ADcdCF8e0ed9D6dd3Df683F076402B79E3bd.toBytes32();
+
     }
 
     function _addBaseValues() private {
@@ -1162,6 +1169,127 @@ contract ChainValues {
         // Compound V3
         values[optimism]["cWETHV3"] = 0xE36A30D249f7761327fd973001A32010b521b6Fd.toBytes32();
         values[optimism]["cometRewards"] = 0x443EA0340cb75a160F31A440722dec7b5bc3C2E9.toBytes32();
+    }
+    function _addSonicMainnetValues() private {
+        values[sonicMainnet]["dev0Address"] = 0x0463E60C7cE10e57911AB7bD1667eaa21de3e79b.toBytes32();
+        values[sonicMainnet]["dev1Address"] = 0xf8553c8552f906C19286F21711721E206EE4909E.toBytes32();
+        values[sonicMainnet]["deployerAddress"] = 0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d.toBytes32();
+        values[sonicMainnet]["txBundlerAddress"] = 0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d.toBytes32();
+
+        // ERC20
+        values[sonicMainnet]["ETH"] = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE.toBytes32(); //$S token
+        values[sonicMainnet]["WETH"] = 0x50c42dEAcD8Fc9773493ED674b675bE577f2634b.toBytes32();
+        values[sonicMainnet]["USDC"] = 0x29219dd400f2Bf60E5a23d13Be72B486D4038894.toBytes32();
+        values[sonicMainnet]["USDT"] = 0x6047828dc181963ba44974801FF68e538dA5eaF9.toBytes32();
+        values[sonicMainnet]["wS"] = 0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38.toBytes32();
+        values[sonicMainnet]["stS"] = 0xE5DA20F15420aD15DE0fa650600aFc998bbE3955.toBytes32();
+        values[sonicMainnet]["scUSD"] = 0xd3DCe716f3eF535C5Ff8d041c1A41C3bd89b97aE.toBytes32();
+        values[sonicMainnet]["scETH"] = 0x3bcE5CB273F0F148010BbEa2470e7b5df84C7812.toBytes32();
+        values[sonicMainnet]["scBTC"] = 0xBb30e76d9Bb2CC9631F7fC5Eb8e87B5Aff32bFbd.toBytes32();
+        values[sonicMainnet]["stkscUSD"] = 0x4D85bA8c3918359c78Ed09581E5bc7578ba932ba.toBytes32();
+        values[sonicMainnet]["EBTC"] = 0x657e8C867D8B37dCC18fA4Caead9C45EB088C642.toBytes32();
+        values[sonicMainnet]["LBTC"] = 0xecAc9C5F704e954931349Da37F60E39f515c11c1.toBytes32();
+        values[sonicMainnet]["WBTC"] = 0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.toBytes32(); //also OFT
+        values[sonicMainnet]["BEETS"] = 0x2D0E0814E62D80056181F5cd932274405966e4f0.toBytes32(); 
+        values[sonicMainnet]["rEUL"] = 0x09E6cab47B7199b9d3839A2C40654f246d518a80.toBytes32(); 
+        values[sonicMainnet]["EUL"] = 0x8e15C8D399e86d4FD7B427D42f06c60cDD9397e7.toBytes32(); 
+        values[sonicMainnet]["ZRO"] = address(1).toBytes32();
+        values[sonicMainnet]["OS"] = 0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794.toBytes32();
+
+        values[sonicMainnet]["balancerVault"] = address(1).toBytes32();
+        values[sonicMainnet]["vault"] = address(1).toBytes32();
+
+        // UniswapV3
+        values[sonicMainnet]["uniswapV3NonFungiblePositionManager"] = 0x743E03cceB4af2efA3CC76838f6E8B50B63F184c.toBytes32();
+        values[sonicMainnet]["uniV3Router"] = 0xaa52bB8110fE38D0d2d2AF0B85C3A3eE622CA455.toBytes32();
+
+        // Beets/Balancer
+        values[sonicMainnet]["balancerVault"] = 0xBA12222222228d8Ba445958a75a0704d566BF2C8.toBytes32();
+
+        values[sonicMainnet]["scUSD_USDC_gauge"] = 0x33B29bcf17e866A35941e07CbAd54f1807B337f5.toBytes32();
+        values[sonicMainnet]["scETH_WETH_gauge"] = 0x8828a6e3166cac78F3C90A5b5bf17618BDAf1Deb.toBytes32();
+        values[sonicMainnet]["scBTC_LBTC_gauge"] = 0x11c43F630b52F1271a5005839d34b07C0C125e72.toBytes32();
+
+        values[sonicMainnet]["scUSD_USDC_PoolId"] = 0xcd4d2b142235d5650ffa6a38787ed0b7d7a51c0c000000000000000000000037;
+        values[sonicMainnet]["scETH_WETH_PoolId"] = 0xe54dd58a6d4e04687f2034dd4ddab49da55f8aff00000000000000000000007c;
+        values[sonicMainnet]["USDC_stS_PoolId"] =  0x713fb5036dc70012588d77a5b066f1dd05c712d7000200000000000000000041;
+        values[sonicMainnet]["USDC_wS_PoolId"] =  0xfc127dfc32b7739a7cfff7ed19e4c4ab3221953a0002000000000000000000a4;
+        values[sonicMainnet]["stS_BEETS_PoolId"] =  0x10ac2f9dae6539e77e372adb14b1bf8fbd16b3e8000200000000000000000005;
+        values[sonicMainnet]["USDC_WETH_PoolId"] =  0x308ebea1dc4ead75f0aebd1569e39354e26ae9e600020000000000000000009c;
+        values[sonicMainnet]["scBTC_LBTC_PoolId"] = 0x83952912178aa33c3853ee5d942c96254b235dcc0002000000000000000000ab;
+
+
+        values[sonicMainnet]["scBTC_LBTC_PoolId"] = 0x83952912178aa33c3853ee5d942c96254b235dcc0002000000000000000000ab;
+
+        // Tellers
+        values[sonicMainnet]["scUSDTeller"] = 0x358CFACf00d0B4634849821BB3d1965b472c776a.toBytes32();
+        values[sonicMainnet]["scETHTeller"] = 0x31A5A9F60Dc3d62fa5168352CaF0Ee05aA18f5B8.toBytes32();
+        values[sonicMainnet]["stkscUSDTeller"] = 0x5e39021Ae7D3f6267dc7995BB5Dd15669060DAe0.toBytes32();
+        values[sonicMainnet]["stkscETHTeller"] = 0x49AcEbF8f0f79e1Ecb0fd47D684DAdec81cc6562.toBytes32();
+
+        // Accountant
+        values[sonicMainnet]["scUSDAccountant"] = 0xA76E0F54918E39A63904b51F688513043242a0BE.toBytes32();
+        values[sonicMainnet]["scETHAccountant"] = 0x3a592F9Ea2463379c4154d03461A73c484993668.toBytes32();
+        values[sonicMainnet]["stkscUSDAccountant"] = 0x13cCc810DfaA6B71957F2b87060aFE17e6EB8034.toBytes32();
+        values[sonicMainnet]["stkscETHAccountant"] = 0x61bE1eC20dfE0197c27B80bA0f7fcdb1a6B236E2.toBytes32();
+
+        // Layer Zero
+        values[sonicMainnet]["LayerZeroEndPoint"] = 0x6F475642a6e85809B1c36Fa62763669b1b48DD5B.toBytes32();
+        values[sonicMainnet]["LBTC_OFT"] = 0x630e12D53D4E041b8C5451aD035Ea841E08391d7.toBytes32();
+
+        // Sonic Gateway
+        values[sonicMainnet]["sonicGateway"] = 0x9Ef7629F9B930168b76283AdD7120777b3c895b3.toBytes32();
+        values[sonicMainnet]["circleTokenAdapter"] = 0xe6DCD54B4CDe2e9E935C22F57EBBBaaF5cc3BC8a.toBytes32();
+
+        //Rings
+        values[sonicMainnet]["scUSDVoter"] = 0xF365C45B6913BE7Ab74C970D9227B9D0dfF44aFb.toBytes32(); 
+        values[sonicMainnet]["scETHVoter"] = 0x9842be0f52569155fA58fff36E772bC79D92706e.toBytes32(); 
+
+        // Silo
+        values[sonicMainnet]["siloRouter"] = 0x22AacdEc57b13911dE9f188CF69633cC537BdB76.toBytes32();
+        values[sonicMainnet]["silo_stS_wS_config"] = 0x78C246f67c8A6cE03a1d894d4Cf68004Bd55Deea.toBytes32();
+        values[sonicMainnet]["silo_wS_USDC_id8_config"] = 0x4915F6d3C9a7B20CedFc5d3854f2802f30311d13.toBytes32();
+        values[sonicMainnet]["silo_wS_USDC_id20_config"] = 0x062A36Bbe0306c2Fd7aecdf25843291fBAB96AD2.toBytes32();
+        values[sonicMainnet]["silo_USDC_wstkscUSD_id23_config"] = 0xbC24c0F594ECA381956895957c771437D61400D3.toBytes32();
+        values[sonicMainnet]["silo_S_ETH_config"] = 0x9603Af53dC37F4BB6386f358A51a04fA8f599101.toBytes32();
+        values[sonicMainnet]["silo_ETH_wstkscETH_config"] = 0xefA367570B11f8745B403c0D458b9D2EAf424686.toBytes32();
+        values[sonicMainnet]["silo_S_scUSD_id15_config"] = 0xFe514E71F0933F63B374056557AED3dBB381C646.toBytes32();
+        values[sonicMainnet]["silo_LBTC_scBTC_id32_config"] = 0xe67cce118e9CcEaE51996E4d290f9B77D960E3d7.toBytes32();
+
+
+         // Curve
+        values[sonicMainnet]["curve_USDC_scUSD_pool"] = 0x2Fd7CCDa50ED88fe17E15f3d5D8d51da4CCB43F3.toBytes32();
+        values[sonicMainnet]["curve_USDC_scUSD_gauge"] = 0x12F89168C995e54Ec2ce9ee461D663a6dC72793A.toBytes32();
+
+         // Euler
+        values[sonicMainnet]["ethereumVaultConnector"] = 0x4860C903f6Ad709c3eDA46D3D502943f184D4315.toBytes32();
+        values[sonicMainnet]["euler_scETH_MEV"] = 0x0806af1762Bdd85B167825ab1a64E31CF9497038.toBytes32();
+        values[sonicMainnet]["euler_WETH_MEV"] = 0xa5cd24d9792F4F131f5976Af935A505D19c8Db2b.toBytes32();
+        values[sonicMainnet]["euler_scUSD_MEV"] = 0xB38D431e932fEa77d1dF0AE0dFE4400c97e597B8.toBytes32();
+        values[sonicMainnet]["euler_USDC_MEV"] = 0x196F3C7443E940911EE2Bb88e019Fd71400349D9.toBytes32();
+        values[sonicMainnet]["euler_USDC_RE7"] = 0x3D9e5462A940684073EED7e4a13d19AE0Dcd13bc.toBytes32();
+        values[sonicMainnet]["euler_scUSD_RE7"] = 0xeEb1DC1Ca7ffC5b54aD1cc4c1088Db4E5657Cb6c.toBytes32();
+
+        // Curve
+        values[sonicMainnet]["curve_WETH_scETH_pool"] = 0xfF11f56281247EaD18dB76fD23b252156738FA94.toBytes32();
+        values[sonicMainnet]["curve_WETH_scETH_gauge"] = 0x4F7Fc3F5112eAef10495B04b5dd376E50c42dA51.toBytes32();
+
+        // Odos
+        values[sonicMainnet]["odosRouterV2"] = 0xaC041Df48dF9791B0654f1Dbbf2CC8450C5f2e9D.toBytes32();
+        values[sonicMainnet]["odosExecutor"] = 0xB28Ca7e465C452cE4252598e0Bc96Aeba553CF82.toBytes32();
+        
+        // Aave
+        values[sonicMainnet]["v3Pool"] = 0x5362dBb1e601abF3a4c14c22ffEdA64042E5eAA3.toBytes32();
+        values[sonicMainnet]["v3RewardsController"] = 0x24bD6e9ca54F1737467DEf82dCA9702925B3Aa59.toBytes32();
+        values[sonicMainnet]["awS"] = 0x6C5E14A212c1C3e4Baf6f871ac9B1a969918c131.toBytes32(); 
+         
+        // Merkl
+        values[sonicMainnet]["merklDistributor"] = 0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae.toBytes32();
+
+        // Royco
+        values[sonicMainnet]["recipeMarketHub"] = 0xFcc593aD3705EBcd72eC961c63eb484BE795BDbD.toBytes32();
+        values[sonicMainnet]["vaultMarketHub"] = 0x1e3fCccbafDBdf3cB17b7470c8A6cC64eb5f94A2.toBytes32();
+        values[sonicMainnet]["originSonicWrappedVault"] = 0x7F24390EF4F8c1a372524fF1fA3a1d79D66D86cA.toBytes32();
     }
 
     function _addHoleskyValues() private {


### PR DESCRIPTION
**Current Royco Functions:**

RecipeMarketHub:

- createAPOffer
- fillIPOffers
- cancelAPOffer
- forfeit
- executeWithdrawalScript
- claim *only implemented claiming all assets, individual claims not added after checking in meeting

VaultMarketHub:

- createAPOffer

WrappedVault:

- safeDeposit
- claim
- deposit, withdraw, mint, redeem (via 4626 decoder)


*slightly modified for older version of BaseDecoderAndSanitizer, see main repo here: https://github.com/Veda-Labs/boring-vault/pull/188